### PR TITLE
allow custom query options to be provided

### DIFF
--- a/lib/json_api_client/connection.rb
+++ b/lib/json_api_client/connection.rb
@@ -27,7 +27,7 @@ module JsonApiClient
       faraday.builder.delete(middleware)
     end
 
-    def run(request_method, path, params = {}, headers = {})
+    def run(request_method, path, params = {}, headers = {}, options = {})
       faraday.send(request_method, path, params, headers)
     end
 

--- a/lib/json_api_client/query/builder.rb
+++ b/lib/json_api_client/query/builder.rb
@@ -13,6 +13,7 @@ module JsonApiClient
         @includes = []
         @orders = []
         @fields = []
+        @options = {}
       end
 
       def where(conditions = {})
@@ -54,6 +55,11 @@ module JsonApiClient
         self
       end
 
+      def options(opts)
+        @options = opts
+        self
+      end
+
       def first
         paginate(page: 1, per_page: 1).to_a.first
       end
@@ -85,7 +91,7 @@ module JsonApiClient
           @primary_key = args
         end
 
-        klass.requestor.get(params)
+        klass.requestor.get(params, @options)
       end
 
       def method_missing(method_name, *args, &block)

--- a/lib/json_api_client/query/requestor.rb
+++ b/lib/json_api_client/query/requestor.rb
@@ -8,30 +8,30 @@ module JsonApiClient
       end
 
       # expects a record
-      def create(record)
+      def create(record, options = {})
         request(:post, klass.path(record.attributes), {
           data: record.as_json_api
-        })
+        }, options)
       end
 
-      def update(record)
+      def update(record, options = {})
         request(:patch, resource_path(record.attributes), {
           data: record.as_json_api
-        })
+        }, options)
       end
 
-      def get(params = {})
+      def get(params = {}, options = {})
         path = resource_path(params)
         params.delete(klass.primary_key)
-        request(:get, path, params)
+        request(:get, path, params, options)
       end
 
-      def destroy(record)
-        request(:delete, resource_path(record.attributes), {})
+      def destroy(record, options = {})
+        request(:delete, resource_path(record.attributes), {}, options)
       end
 
-      def linked(path)
-        request(:get, path, {})
+      def linked(path, options = {})
+        request(:get, path, {}, options)
       end
 
       def custom(method_name, options, params)
@@ -39,7 +39,10 @@ module JsonApiClient
         params.delete(klass.primary_key)
         path = File.join(path, method_name.to_s)
 
-        request(options.fetch(:request_method, :get), path, params)
+        request_options = options ? options.dup : {}
+        request_method = request_options.delete(:request_method) || :get
+
+        request(request_method, path, params, request_options)
       end
 
       protected
@@ -59,8 +62,8 @@ module JsonApiClient
         Addressable::URI.encode_component(part, Addressable::URI::CharacterClasses::UNRESERVED)
       end
 
-      def request(type, path, params)
-        klass.parser.parse(klass, connection.run(type, path, params, klass.custom_headers))
+      def request(type, path, params, options = {})
+        klass.parser.parse(klass, connection.run(type, path, params, klass.custom_headers, options))
       end
 
     end

--- a/lib/json_api_client/resource.rb
+++ b/lib/json_api_client/resource.rb
@@ -48,7 +48,7 @@ module JsonApiClient
 
     class << self
       extend Forwardable
-      def_delegators :_new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :first, :find
+      def_delegators :_new_scope, :where, :order, :includes, :select, :all, :paginate, :page, :options, :first, :find
 
       # The table name for this resource. i.e. Article -> articles, Person -> people
       #

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ end
 
 WebMock.disable_net_connect!(:allow => "codeclimate.com")
 
+require 'json_api_client'
 class TestResource < JsonApiClient::Resource
   self.site = "http://example.com/"
 end

--- a/test/unit/query_builder_test.rb
+++ b/test/unit/query_builder_test.rb
@@ -95,4 +95,12 @@ class QueryBuilderTest < MiniTest::Test
     articles = Article.select("title,body").to_a
   end
 
+  def test_can_provide_options
+    stub_request(:get, "http://example.com/articles")
+      .to_return(headers: {content_type: "application/vnd.api+json"}, body: {
+        data: []
+      }.to_json)
+    articles = Article.options('foo' => 'bar').to_a
+  end
+
 end


### PR DESCRIPTION
allows the requestor to take a hash of custom options for each request method. adds `options` to the query builder dsl to allow custom options to be provided for finders. custom options can be used by a custom connection to influence its behavior.